### PR TITLE
解决 Emby 4.8 版本弹幕问题，CORS报错

### DIFF
--- a/ede.js
+++ b/ede.js
@@ -39,7 +39,7 @@
             is: 'paper-icon-button-light',
         };
         const uiAnchorStr = '\uE034';
-        const mediaContainerQueryStr = "div[data-type='video-osd']";
+        const mediaContainerQueryStr = ".graphicContentContainer";
         const mediaQueryStr = 'video';
         const displayButtonOpts = {
             title: '弹幕开关',

--- a/ede.js
+++ b/ede.js
@@ -3,7 +3,7 @@
 // @description  Emby弹幕插件
 // @namespace    https://github.com/RyoLee
 // @author       RyoLee
-// @version      1.12
+// @version      1.13
 // @copyright    2022, RyoLee (https://github.com/RyoLee)
 // @license      MIT; https://raw.githubusercontent.com/RyoLee/emby-danmaku/master/LICENSE
 // @icon         https://github.githubassets.com/pinned-octocat.svg
@@ -517,8 +517,7 @@
                 animeName = prompt('确认动画名:', animeName);
                 if (animeName == null) throw new Error('用户取消确认动画名操作');
             }
-
-            let searchUrl = 'https://api.dandanplay.net/api/v2/search/episodes?anime=' + animeName + '&withRelated=true';
+            let searchUrl = 'https://ddplay-api.930524.xyz/cors/https://api.dandanplay.net/api/v2/search/episodes?anime=' + animeName + '&withRelated=true';
             if (is_auto) {
                 searchUrl += '&episode=' + episode;
             }
@@ -571,7 +570,7 @@
         }
 
         function getComments(episodeId) {
-            let url = 'https://api.9-ch.com/cors/https://api.dandanplay.net/api/v2/comment/' + episodeId + '?withRelated=true&chConvert=' + window.ede.chConvert;
+            let url = 'https://ddplay-api.930524.xyz/cors/https://api.dandanplay.net/api/v2/comment/' + episodeId + '?withRelated=true&chConvert=' + window.ede.chConvert;
             return fetch(url, {
                 method: 'GET',
                 headers: {


### PR DESCRIPTION
新版本的 Emby Server （例如 4.8 以上）已经移除了播放页面内的 `div[data-type='video-osd']`，导致现有版本不能显示弹幕。这个 PR 更改成使用 `<div class = "graphicContentContainer">`来插入弹幕，并且这个 div 在非播放页面时会隐藏起来。

<img width="1727" alt="image" src="https://github.com/9channel/dd-danmaku/assets/57316431/75f4703a-8139-4d0f-984e-22821c352fde">
