### PR TITLE
添加处理OPTIONS请求的方法

### DIFF
--- a/cf_worker.js
+++ b/cf_worker.js
@@ -1,6 +1,17 @@
 const hostlist = { 'api.dandanplay.net': null };
 
 async function handleRequest(request) {
+    if (request.method === 'OPTIONS') {
+        return new Response(null, {
+            status: 204,
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type, Authorization, User-Agent',
+            },
+        });
+    }
+
     const urlObj = new URL(request.url);
     let url = urlObj.href.replace(urlObj.origin + '/cors/', '').trim();
     if (0 !== url.indexOf('https://') && 0 === url.indexOf('https:')) {


### PR DESCRIPTION
添加处理OPTIONS请求的方法，safari浏览器会通过OPTIONS请求用于CORS预检，如果不处理OPTIONS请求，会导致在safari浏览器中报错405